### PR TITLE
QR generation

### DIFF
--- a/ModernPantryBackend/Controllers/QRController.cs
+++ b/ModernPantryBackend/Controllers/QRController.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.Net.Http;
+
+namespace ModernPantryBackend.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class QRController : ControllerBase
+    {
+        private readonly HttpClient _httpClient;
+        private readonly string _qrApiLink;
+
+        public QRController(HttpClient httpClient, IConfiguration configuration)
+        {
+            _httpClient = httpClient;
+            _qrApiLink = configuration["QrApiLink"];
+        }
+
+        [HttpGet]
+        public async Task<ServiceResponse> GetQR(string url)
+        {
+            var request = _qrApiLink + url;
+            var response = await _httpClient.GetByteArrayAsync(request);
+            return ServiceResponse<byte[]>.Success(response, "Qr code generated.");
+        }
+    }
+}

--- a/ModernPantryBackend/Program.cs
+++ b/ModernPantryBackend/Program.cs
@@ -18,6 +18,9 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services.AddScoped(sp => new HttpClient());
+builder.Services.AddHttpContextAccessor();
+
 builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
 
 builder.Services.AddDbContext<DataContext>(options => options.UseSqlServer(builder.Configuration.GetConnectionString("ModernPantryDBConnection")));

--- a/ModernPantryBackend/appsettings.json
+++ b/ModernPantryBackend/appsettings.json
@@ -8,5 +8,6 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "QrApiLink": "https://api.qrserver.com/v1/create-qr-code/?size=500x500&data="
 }


### PR DESCRIPTION
Sending GET request with URL as parameter (eg. link to product with id 3712 https://pantry-website.com/products/3712) will return a QR code image encoded in Base64